### PR TITLE
Add code checking if node is up-to-date or not before calling start listening

### DIFF
--- a/internal/controller.go
+++ b/internal/controller.go
@@ -320,6 +320,15 @@ func (c *Controller) Start() error {
 		if listener.IsDisabled() {
 			continue
 		}
+		// check whether node is up-to-date or not
+		// it guarantees that blocks data are consistent to other nodes
+		for {
+			if listener.IsUpTodate() {
+				break
+			}
+			// sleep for 10s
+			time.Sleep(10 * time.Second)
+		}
 		go c.startListener(listener, 0)
 	}
 	return nil

--- a/internal/listener/ethereum.go
+++ b/internal/listener/ethereum.go
@@ -155,6 +155,10 @@ func (e *EthereumListener) GetCurrentBlock() types.IBlock {
 	return e.currentBlock.Load().(types.IBlock)
 }
 
+func (e *EthereumListener) IsUpTodate() bool {
+	return true
+}
+
 func (e *EthereumListener) GetProcessedBlock() (types.IBlock, error) {
 	chainId, err := e.GetChainID()
 	if err != nil {

--- a/internal/listener/ronin.go
+++ b/internal/listener/ronin.go
@@ -69,6 +69,16 @@ func (l *RoninListener) StoreMainchainWithdrawCallback(fromChainId *big.Int, tx 
 	})
 }
 
+func (l *RoninListener) IsUpTodate() bool {
+	latestBlock, err := l.GetLatestBlock()
+	if err != nil {
+		log.Error("[RoninListener][IsUpTodate] error while get latest block", "err", err, "listener", l.GetName())
+		return false
+	}
+	// true if timestamp is within 1 hour
+	return uint64(time.Now().Unix())-latestBlock.GetTimestamp() <= uint64(time.Hour)
+}
+
 func (l *RoninListener) ProvideReceiptSignatureCallback(fromChainId *big.Int, tx types.ITransaction, data []byte) error {
 	// check database if receipt exist then do nothing
 	// Unpack event from data

--- a/internal/listener/types.go
+++ b/internal/listener/types.go
@@ -63,6 +63,10 @@ func (b *EthBlock) GetLogs() []types.ILog {
 	return b.logs
 }
 
+func (b *EthBlock) GetTimestamp() uint64 {
+	return b.block.Time()
+}
+
 type EthTransaction struct {
 	chainId *big.Int
 	sender  common.Address

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -81,6 +81,8 @@ type IListener interface {
 
 	GetEthClient() utils.EthClient
 	GetTask() ITask
+
+	IsUpTodate() bool
 }
 
 type IEthListener interface {
@@ -117,6 +119,7 @@ type IBlock interface {
 	GetHeight() uint64
 	GetTransactions() []ITransaction
 	GetLogs() []ILog
+	GetTimestamp() uint64
 }
 
 type IJob interface {


### PR DESCRIPTION
To guarantee blocks are consistent with other nodes, bridge should make sure the node is up-to-date. In this case, current block's timestamp should be within current time 1 hour.