### PR TITLE
Call to contract even when actions are executed

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,8 +21,8 @@ require (
 
 require (
 	github.com/DATA-DOG/go-sqlmock v1.5.0
-	github.com/axieinfinity/bridge-contracts v0.0.0-20220731110242-d273b578b657
-	github.com/axieinfinity/bridge-core v0.1.1
+	github.com/axieinfinity/bridge-contracts v0.0.0-20221114085145-8b4c19bf4317
+	github.com/axieinfinity/bridge-core v0.1.2-0.20221031095024-7319520259bf
 	github.com/axieinfinity/bridge-migrations v0.0.0-20220803051308-adab1cd1bcca
 	github.com/axieinfinity/ronin-kms-client v0.0.0-20220805072849-960e04981b70
 	github.com/ethereum/go-ethereum v1.10.21

--- a/go.sum
+++ b/go.sum
@@ -49,6 +49,12 @@ github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk5
 github.com/allegro/bigcache v1.2.1-0.20190218064605-e24eb225f156 h1:eMwmnE/GDgah4HI848JfFxHt+iPb26b4zyfspmqY0/8=
 github.com/allegro/bigcache v1.2.1-0.20190218064605-e24eb225f156/go.mod h1:Cb/ax3seSYIx7SuZdm2G2xzfwmv3TPSk2ucNfQESPXM=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
+github.com/axieinfinity/bridge-contracts v0.0.0-20221114085145-8b4c19bf4317 h1:lVc3FSS+M8/Z7KdB7YB4dfVnrXwJErf+n+aBxu3r/WI=
+github.com/axieinfinity/bridge-contracts v0.0.0-20221114085145-8b4c19bf4317/go.mod h1:/1xWUM5AIZGYgaFxl9ojlw3tCgeWF4SDg8qrzx5YHwk=
+github.com/axieinfinity/bridge-core v0.1.1 h1:zkrPwxx6S8Ww4ycyF0Ap/5MaJz/1THP7juiA9f4Lvvs=
+github.com/axieinfinity/bridge-core v0.1.1/go.mod h1:HHk3GbxJ6DTA2A/ZKOZJG4XVdwB480leaMYL29xWqCI=
+github.com/axieinfinity/bridge-core v0.1.2-0.20221031095024-7319520259bf h1:86AiUhF3ZQ+6qpIdD3KZSjD3Ooo9xYPexFkoQVehY+U=
+github.com/axieinfinity/bridge-core v0.1.2-0.20221031095024-7319520259bf/go.mod h1:rsKGb45uQio1Rpqsc7grYyZEBn/fEPFyamJ55pQz1Fk=
 github.com/axieinfinity/bridge-migrations v0.0.0-20220803051308-adab1cd1bcca h1:Bmy5XEh5VFhKIE04Yvnmvr47AjzWZFJF9I3aedxaAQE=
 github.com/axieinfinity/bridge-migrations v0.0.0-20220803051308-adab1cd1bcca/go.mod h1:jkGvoA7823lFnjPcYf1rMn4kaJv5qiYwGLP1PUc+T7o=
 github.com/axieinfinity/ronin-kms-client v0.0.0-20220805072849-960e04981b70 h1:4MMSxt0Ce9cCN/XB+ESc/JllU1/jklFiIsWG4gq2y+g=


### PR DESCRIPTION
As DPOS has bridge tracking for every bridge operator to distribute reward, all operators must vote on every action to avoid slashing even when that action is executed.