### PR TITLE
feat: add gateway contract version detection

### DIFF
--- a/config/config.mainnet.json
+++ b/config/config.mainnet.json
@@ -9,7 +9,7 @@
       "minTasksQuery": 50,
       "taskInterval": 10,
       "transactionCheckPeriod": 50,
-      "gasLimitBumpRatio": 200,
+      "gasLimitBumpRatio": 300,
       "secret": {
         "bridgeOperator": {
           "plainPrivateKey": ""

--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 
 require (
 	github.com/DATA-DOG/go-sqlmock v1.5.0
-	github.com/axieinfinity/bridge-contracts v0.0.0-20230403071733-9fca121e6448
+	github.com/axieinfinity/bridge-contracts v0.0.0-20231004085724-072c76e1bf73
 	github.com/axieinfinity/bridge-core v0.1.2-0.20230417033945-8258b81bcbe5
 	github.com/axieinfinity/bridge-migrations v0.0.0-20230405070530-7bb3be2afe72
 	github.com/axieinfinity/ronin-kms-client v0.0.0-20220805072849-960e04981b70

--- a/go.sum
+++ b/go.sum
@@ -50,6 +50,8 @@ github.com/allegro/bigcache v1.2.1-0.20190218064605-e24eb225f156 h1:eMwmnE/GDgah
 github.com/allegro/bigcache v1.2.1-0.20190218064605-e24eb225f156/go.mod h1:Cb/ax3seSYIx7SuZdm2G2xzfwmv3TPSk2ucNfQESPXM=
 github.com/axieinfinity/bridge-contracts v0.0.0-20230403071733-9fca121e6448 h1:WqnLoL92C6UmDIGPNqZhdFIq7mJiNT18++A1k+cYzFk=
 github.com/axieinfinity/bridge-contracts v0.0.0-20230403071733-9fca121e6448/go.mod h1:/1xWUM5AIZGYgaFxl9ojlw3tCgeWF4SDg8qrzx5YHwk=
+github.com/axieinfinity/bridge-contracts v0.0.0-20231004085724-072c76e1bf73 h1:+Y8ThUCfxdKrQWOPtrYvw/52Cq8GOkZzzTqqde1vK8I=
+github.com/axieinfinity/bridge-contracts v0.0.0-20231004085724-072c76e1bf73/go.mod h1:/1xWUM5AIZGYgaFxl9ojlw3tCgeWF4SDg8qrzx5YHwk=
 github.com/axieinfinity/bridge-core v0.1.2-0.20230403071736-4bfcaa15bace h1:CY9T5tZiB+d/Mda7LmnyWTOCJRvBvneRkFnvooFyjzc=
 github.com/axieinfinity/bridge-core v0.1.2-0.20230403071736-4bfcaa15bace/go.mod h1:rsKGb45uQio1Rpqsc7grYyZEBn/fEPFyamJ55pQz1Fk=
 github.com/axieinfinity/bridge-core v0.1.2-0.20230417033945-8258b81bcbe5 h1:CxmEOM71sG/7X9baM2xtgY/F8daycwkKZeTXAfudHlM=
@@ -88,6 +90,8 @@ github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5P
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
+github.com/cncf/udpa/go v0.0.0-20210930031921-04548b0d99d4/go.mod h1:6pvJx4me5XPnfI9Z40ddWsdw2W/uZgQLFXToKeRcDiI=
+github.com/cncf/xds/go v0.0.0-20211011173535-cb28da3451f1/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/cockroachdb/apd v1.1.0 h1:3LFP3629v+1aKXU5Q37mxmRxX/pIu1nijXydLShEq5I=
 github.com/cockroachdb/apd v1.1.0/go.mod h1:8Sl8LxpKi29FqWXR16WEFZRNSz3SoPzUzeMeY4+DwBQ=
 github.com/common-nighthawk/go-figure v0.0.0-20210622060536-734e95fb86be h1:J5BL2kskAlV9ckgEsNQXscjIaLiOYiZ75d4e94E6dcQ=
@@ -109,6 +113,7 @@ github.com/edsrzf/mmap-go v1.1.0/go.mod h1:19H/e8pUPLicwkyNgOykDXkJ9F0MHE+Z52B8E
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=
+github.com/envoyproxy/go-control-plane v0.10.2-0.20220325020618-49ff273808a1/go.mod h1:KJwIaB5Mv44NWtYuAOFCVOjcI94vtpEz2JU/D2v6IjE=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/fjl/memsize v0.0.0-20190710130421-bcb5799ab5e5 h1:FtmdgXiUlNeRsoNMFlKLDt+S+6hbjVMEW6RGQ7aUf7c=
 github.com/fjl/memsize v0.0.0-20190710130421-bcb5799ab5e5/go.mod h1:VvhXpOYNQvB+uIk2RvXzuaQtkQJzzIx6lSBe1xv7hi0=

--- a/task/bulk_task.go
+++ b/task/bulk_task.go
@@ -27,7 +27,8 @@ import (
 )
 
 const (
-	ErrNotBridgeOperator = "execution reverted: RoninGatewayV2: unauthorized sender"
+	ErrNotBridgeOperator      = "execution reverted: RoninGatewayV2: unauthorized sender"
+	BridgeManagerContractType = 11
 )
 
 type bulkTask struct {
@@ -86,11 +87,10 @@ func (r *bulkTask) getSignMethod() utils.ISign {
 		return nil
 	}
 
-	// Bridge tracking contract is only avaible in DPoS version.
+	// getContract is only available in newer version.
 	// If we get error when calling this function, it means it is
-	// in POA version, return legacy bridge operator if it is
-	// provided.
-	_, err = caller.BridgeTrackingContract(nil)
+	// in older version, return legacy bridge operator if it is provided.
+	_, err = caller.GetContract(nil, BridgeManagerContractType)
 	if err != nil && r.listener.GetLegacyBridgeOperatorSign() != nil {
 		log.Debug("[bulkTask][getSignMethod] Use legacy bridge operator key")
 		return r.listener.GetLegacyBridgeOperatorSign()


### PR DESCRIPTION
To ease the upgrade process, this commit adds gateway contract version detection
to switch to new bridge operator account and disable bridge voter functionality
automatically when contract is upgraded.