### PR TITLE
fix: restrict the release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,7 @@
 name: release
 on:
   release:
+    types: [published]
     tags:
       - v*.*.*
 


### PR DESCRIPTION
Currently, when publishing a new release using Github UI, we trigger 3 release workflows. It looks like that 3 action types: created, published, released trigger the workflow. This commit restricts the release workflow to run on published activity type only.

Reference:
- https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#release
- https://docs.github.com/en/webhooks/webhook-events-and-payloads?actionType=published#release