### PR TITLE
chore: add default bridge stats configuration

### DIFF
--- a/config/config.mainnet.json
+++ b/config/config.mainnet.json
@@ -30,6 +30,11 @@
         "Governance": "0x946397deDFd2f79b75a72B322944a21C3240c9c3",
         "TrustedOrganization": "0x98D0230884448B3E2f09a177433D60fb1E19C090"
       },
+      "stats": {
+        "node": "",
+        "host": "",
+        "secret": ""
+      },
       "subscriptions": {
         "MainchainWithdrewSubscription": {
           "to": "0x0CF8fF40a508bdBc39fBe1Bb679dCBa64E65C7Df",

--- a/config/config.mainnet.yaml
+++ b/config/config.mainnet.yaml
@@ -18,6 +18,10 @@ listeners:
         plainPrivateKey: ""
     fromHeight": 14763470
     processWithinBlocks": 864000
+    stats:
+      node: ""
+      host: ""
+      secret: ""
     contracts:
       Gateway: "0x0CF8fF40a508bdBc39fBe1Bb679dCBa64E65C7Df"
       EthGateway: "0x64192819Ac13Ef72bF6b5AE239AC672B43a9AF08"

--- a/config/config.testnet.json
+++ b/config/config.testnet.json
@@ -27,6 +27,11 @@
         "Gateway": "0xCee681C9108c42C710c6A8A949307D5F13C9F3ca",
         "EthGateway": "0x9e359F42cDDc84A386a2Ef1D9Ae06623f3970D1D"
       },
+      "stats": {
+        "node": "",
+        "host": "",
+        "secret": ""
+      },
       "subscriptions": {
         "MainchainWithdrewSubscription": {
           "to": "0xCee681C9108c42C710c6A8A949307D5F13C9F3ca",

--- a/config/config.testnet.yaml
+++ b/config/config.testnet.yaml
@@ -18,6 +18,10 @@ listeners:
         plainPrivateKey: ""
     fromHeight: 8010875
     processWithinBlocks: 864000
+    stats:
+      node: ""
+      host: ""
+      secret: ""
     contracts:
       Gateway: "0xCee681C9108c42C710c6A8A949307D5F13C9F3ca"
       EthGateway: "0x9e359F42cDDc84A386a2Ef1D9Ae06623f3970D1D"


### PR DESCRIPTION
Viper only overrides the configuration with environment variable when that configuration is in config file. This commit adds the default bridge stats configuration to config file.